### PR TITLE
Improvements

### DIFF
--- a/blocks/quick_tabs/add.php
+++ b/blocks/quick_tabs/add.php
@@ -1,4 +1,5 @@
-<?php   
-defined('C5_EXECUTE') or die(_("Access Denied.")); 
-$this->inc("form.php");
-?>
+<?php 
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+$this->inc('form.php');

--- a/blocks/quick_tabs/add.php
+++ b/blocks/quick_tabs/add.php
@@ -1,5 +1,9 @@
 <?php 
 
+/**
+ * @var Concrete\Core\Block\View\BlockView $this
+ */
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
 $this->inc('form.php');

--- a/blocks/quick_tabs/controller.php
+++ b/blocks/quick_tabs/controller.php
@@ -8,6 +8,12 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController
 {
+    public $openclose;
+
+    public $tabTitle;
+
+    public $semantic;
+
     protected $btTable = 'btQuickTabs';
 
     protected $btWrapperClass = 'ccm-ui';

--- a/blocks/quick_tabs/controller.php
+++ b/blocks/quick_tabs/controller.php
@@ -3,6 +3,7 @@
 namespace Concrete\Package\QuickTabs\Block\QuickTabs;
 
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Page\Page;
 use Exception;
 
 defined('C5_EXECUTE') or die('Access Denied.');
@@ -51,6 +52,16 @@ class Controller extends BlockController
     public function getBlockTypeDescription()
     {
         return t('Add Tabs to the Page');
+    }
+    
+    /**
+     * {@inheritDoc}
+     * @see \Concrete\Core\Block\BlockController::ignorePageThemeGridFrameworkContainer()
+     */
+    public function ignorePageThemeGridFrameworkContainer()
+    {
+        $c = Page::getCurrentPage();
+        return $c && !$c->isError() && $c->isEditMode() ? false : true;
     }
 
     public function view()

--- a/blocks/quick_tabs/controller.php
+++ b/blocks/quick_tabs/controller.php
@@ -53,6 +53,11 @@ class Controller extends BlockController
         return t('Add Tabs to the Page');
     }
 
+    public function view()
+    {
+        $this->set('closeOption', static::OPENCLOSE_CLOSE);
+    }
+
     public function add()
     {
         $this->set('openclose', '');
@@ -64,6 +69,10 @@ class Controller extends BlockController
 
     public function edit()
     {
+        // Previous version defined 'H4' instead of 'h4'
+        if ($this->semantic === 'H4') {
+            $this->set('semantic', 'h4');
+        }
         $this->set('opencloseOptions', $this->getOpencloseOptions());
         $this->addOrEdit();
     }

--- a/blocks/quick_tabs/controller.php
+++ b/blocks/quick_tabs/controller.php
@@ -67,6 +67,16 @@ class Controller extends BlockController
 
         return $c && !$c->isError() && $c->isEditMode() ? false : true;
     }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Block\BlockController::registerViewAssets()
+     */
+    public function registerViewAssets($outputContent = '')
+    {
+        $this->requireAsset('javascript', 'jquery');
+    }
 
     public function view()
     {

--- a/blocks/quick_tabs/controller.php
+++ b/blocks/quick_tabs/controller.php
@@ -35,4 +35,11 @@ class Controller extends BlockController
     {
         return t('Add Tabs to the Page');
     }
+
+    public function add()
+    {
+        $this->set('openclose', '');
+        $this->set('tabTitle', '');
+        $this->set('semantic', '');
+    }
 }

--- a/blocks/quick_tabs/controller.php
+++ b/blocks/quick_tabs/controller.php
@@ -1,26 +1,38 @@
 <?php
-namespace Concrete\Package\QuickTabs\Block\QuickTabs;
-use \Concrete\Core\Block\BlockController;
-use Loader;
-use \File;
-use Page;
-use \Concrete\Core\Block\View\BlockView as BlockView;
 
-defined('C5_EXECUTE') or die(_("Access Denied.")); 
+namespace Concrete\Package\QuickTabs\Block\QuickTabs;
+
+use Concrete\Core\Block\BlockController;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
 class Controller extends BlockController
 {
     protected $btTable = 'btQuickTabs';
-    protected $btInterfaceWidth = "400";
+
     protected $btWrapperClass = 'ccm-ui';
-    protected $btInterfaceHeight = "365";
 
-    public function getBlockTypeDescription()
-    {
-        return t("Add Tabs to the Page");
-    }
+    protected $btInterfaceHeight = 365;
 
+    protected $btInterfaceWidth = 400;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Block\BlockController::getBlockTypeName()
+     */
     public function getBlockTypeName()
     {
-        return t("Quick Tabs");
+        return t('Quick Tabs');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Block\BlockController::getBlockTypeDescription()
+     */
+    public function getBlockTypeDescription()
+    {
+        return t('Add Tabs to the Page');
     }
 }

--- a/blocks/quick_tabs/db.xml
+++ b/blocks/quick_tabs/db.xml
@@ -8,5 +8,6 @@
 		<field name="openclose" type="X2"></field>
 		<field name="tabTitle" type="X2"></field>
 		<field name="semantic" type="X2"></field>
+		<field name="tabHandle" type="C2" size="255"></field>
 	</table>
 </schema>

--- a/blocks/quick_tabs/edit.php
+++ b/blocks/quick_tabs/edit.php
@@ -1,4 +1,5 @@
-<?php   
-defined('C5_EXECUTE') or die(_("Access Denied.")); 
-$this->inc("form.php");
-?>
+<?php 
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+$this->inc('form.php');

--- a/blocks/quick_tabs/edit.php
+++ b/blocks/quick_tabs/edit.php
@@ -1,5 +1,9 @@
 <?php 
 
+/**
+ * @var Concrete\Core\Block\View\BlockView $this
+ */
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
 $this->inc('form.php');

--- a/blocks/quick_tabs/form.php
+++ b/blocks/quick_tabs/form.php
@@ -3,8 +3,11 @@
  * @var Concrete\Package\QuickTabs\Block\QuickTabs\Controller $controller
  * @var Concrete\Core\Form\Service\Form $form
  * @var string $openclose
+ * @var array $opencloseOptions
  * @var string $semantic
+ * @var array $semanticOptions
  * @var string $tabTitle
+ * @var string $closeOptionJSON
  */
 
 defined('C5_EXECUTE') or die('Access Denied.');
@@ -12,7 +15,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 <div class="form-group">
     <?php echo $form->label('openclose', t('Is this the Opening or Closing Block?')); ?>
-    <?php echo $form->select('openclose', array('' => '', 'open' => t('Open'), 'close' => t('Close')), $openclose, array('required' => 'required')); ?>
+    <?php echo $form->select('openclose', $opencloseOptions, $openclose, array('required' => 'required')); ?>
 </div>
 
 <div class="form-group<?php echo $openclose === 'close' ? ' hide' : '' ?>">
@@ -22,14 +25,14 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 <div class="form-group<?php echo $openclose === 'close' ? ' hide' : '' ?>">
     <?php echo $form->label('semantic', t('Semantic Tag for the Tab Title')); ?>
-    <?php echo $form->select('semantic', array('h2' => 'H2', 'h3' => 'H3', 'H4' => 'H4', 'p' => 'Paragraph', 'span' => 'Span'), $semantic); ?>
+    <?php echo $form->select('semantic', $semanticOptions, $semantic); ?>
 </div>
 
 <script>
 $(document).ready(function() {
     $('#openclose')
         .on('change', function() {
-            $('#tabTitle,#semantic').closest('.form-group').toggleClass('hide', this.value === 'close');
+            $('#tabTitle,#semantic').closest('.form-group').toggleClass('hide', this.value === <?php echo $closeOptionJSON ?>);
         })
         .trigger('change')
     ;

--- a/blocks/quick_tabs/form.php
+++ b/blocks/quick_tabs/form.php
@@ -1,5 +1,14 @@
 <?php
+/**
+ * @var Concrete\Package\QuickTabs\Block\QuickTabs\Controller $controller
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var string $openclose
+ * @var string $semantic
+ * @var string $tabTitle
+ */
+
 defined('C5_EXECUTE') or die('Access Denied.');
+
 ?>
 <div class="form-group">
     <?php echo $form->label('openclose', t('Is this the Opening or Closing Block?')); ?>

--- a/blocks/quick_tabs/form.php
+++ b/blocks/quick_tabs/form.php
@@ -12,15 +12,26 @@ defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 <div class="form-group">
     <?php echo $form->label('openclose', t('Is this the Opening or Closing Block?')); ?>
-    <?php echo $form->select('openclose', array('open' => t('Open'), 'close' => t('Close')), $openclose); ?>
+    <?php echo $form->select('openclose', array('' => '', 'open' => t('Open'), 'close' => t('Close')), $openclose, array('required' => 'required')); ?>
 </div>
 
-<div class="form-group">
-    <?php echo $form->label('tabTitle', t('If opening, enter a Tab Title:')); ?>
+<div class="form-group<?php echo $openclose === 'close' ? ' hide' : '' ?>">
+    <?php echo $form->label('tabTitle', t('Tab Title')); ?>
     <?php echo $form->text('tabTitle', $tabTitle); ?>
 </div>
 
-<div class="form-group">
-    <?php echo $form->label('semantic', t('For semantics, which tag would you like for the Tab Title:')); ?>
+<div class="form-group<?php echo $openclose === 'close' ? ' hide' : '' ?>">
+    <?php echo $form->label('semantic', t('Semantic Tag for the Tab Title')); ?>
     <?php echo $form->select('semantic', array('h2' => 'H2', 'h3' => 'H3', 'H4' => 'H4', 'p' => 'Paragraph', 'span' => 'Span'), $semantic); ?>
 </div>
+
+<script>
+$(document).ready(function() {
+    $('#openclose')
+        .on('change', function() {
+            $('#tabTitle,#semantic').closest('.form-group').toggleClass('hide', this.value === 'close');
+        })
+        .trigger('change')
+    ;
+});
+</script>

--- a/blocks/quick_tabs/form.php
+++ b/blocks/quick_tabs/form.php
@@ -8,6 +8,7 @@
  * @var array $semanticOptions
  * @var string $tabTitle
  * @var string $closeOptionJSON
+ * @var string $tabHandle
  */
 
 defined('C5_EXECUTE') or die('Access Denied.');
@@ -28,11 +29,16 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <?php echo $form->select('semantic', $semanticOptions, $semantic); ?>
 </div>
 
+<div class="form-group<?php echo $openclose === 'close' ? ' hide' : '' ?>">
+    <?php echo $form->label('tabHandle', t('Tab Handle')); ?>
+    <?php echo $form->text('tabHandle', $tabHandle, array('maxlength' => 255)); ?>
+</div>
+
 <script>
 $(document).ready(function() {
     $('#openclose')
         .on('change', function() {
-            $('#tabTitle,#semantic').closest('.form-group').toggleClass('hide', this.value === <?php echo $closeOptionJSON ?>);
+            $('#tabTitle,#semantic,#tabHandle').closest('.form-group').toggleClass('hide', this.value === <?php echo $closeOptionJSON ?>);
         })
         .trigger('change')
     ;

--- a/blocks/quick_tabs/form.php
+++ b/blocks/quick_tabs/form.php
@@ -1,15 +1,17 @@
-<?php  defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+?>
 <div class="form-group">
-    <?php echo $form->label('openclose', t('Is this the Opening or Closing Block?'));?>
-    <?php echo $form->select('openclose', array("open"=>t("Open"),"close"=>t("Close")), $openclose); ?>
+    <?php echo $form->label('openclose', t('Is this the Opening or Closing Block?')); ?>
+    <?php echo $form->select('openclose', array('open' => t('Open'), 'close' => t('Close')), $openclose); ?>
 </div>
 
 <div class="form-group">
-    <?php echo $form->label('tabTitle', t('If opening, enter a Tab Title:'));?>
-    <?php echo $form->text('tabTitle', $tabTitle);?>
+    <?php echo $form->label('tabTitle', t('If opening, enter a Tab Title:')); ?>
+    <?php echo $form->text('tabTitle', $tabTitle); ?>
 </div>
 
 <div class="form-group">
-    <?php echo $form->label('semantic', t('For semantics, which tag would you like for the Tab Title:'));?>
-    <?php echo $form->select('semantic', array("h2"=>"H2","h3"=>"H3","H4"=>"H4","p"=>"Paragraph","span"=>"Span"),$semantic);?>
+    <?php echo $form->label('semantic', t('For semantics, which tag would you like for the Tab Title:')); ?>
+    <?php echo $form->select('semantic', array('h2' => 'H2', 'h3' => 'H3', 'H4' => 'H4', 'p' => 'Paragraph', 'span' => 'Span'), $semantic); ?>
 </div>

--- a/blocks/quick_tabs/view.js
+++ b/blocks/quick_tabs/view.js
@@ -55,7 +55,11 @@ var LocationHash = (function() {
                 window.document.body.scrollTop = y;
             }
         } else {
-            window.location.hash = hash;
+            try {
+                window.history.replaceState(null, '', '#' + hash);
+            } catch (e) {
+                window.location.hash = hash;
+            }
         }
     }
     return {

--- a/blocks/quick_tabs/view.js
+++ b/blocks/quick_tabs/view.js
@@ -131,7 +131,7 @@ function QuickTabs($container, index) {
             my.handleToTabIndexMap[tabIndex.toString()] = tabIndex;
         }
         $openTag.after($('<h2 class="tab-title" />').html(title));
-        $contents.append($openTag.nextUntil('.simpleTabsClose'));
+        $contents.append($openTag.nextUntil('.simpleTabsClose,.simpleTabsOpen'));
     });
     $openTags.remove();
     $container.find('>.simpleTabsClose').remove();

--- a/blocks/quick_tabs/view.js
+++ b/blocks/quick_tabs/view.js
@@ -1,33 +1,93 @@
-var i=1;
-$(".simpleTabsOpen").each(function(){
-    if(i==1){
-        $(".simpleTabsOpen:first").before("<ul class='simpleTabs clearfix'></ul><div class='simpleTabsContainer'></div>");  
+/* jshint unused:vars, undef:true, browser:true, jquery:true */
+(function() {
+'use strict';
+
+var WINDOW_WIDTH_STOP = 768;
+
+function QuickTabs($container) {
+    var my = this,
+        $openTags = $container.find('>.simpleTabsOpen'),
+        $firstOpenTag = $openTags.first(),
+        wrapperOpen = ($firstOpenTag.data('wrapper-open') || '').toString(),
+        wrapperClose = ($firstOpenTag.data('wrapper-close') || '').toString()
+    ;
+    my.$headersContainer = $('<ul class="simpleTabs clearfix" />');
+    my.$contentsContainer = $('<div class="simpleTabsContainer" />');
+    if (wrapperOpen === '' && wrapperClose === '') {
+        $firstOpenTag
+            .before(my.$headersContainer)
+            .before(my.$contentsContainer)
+        ;
+    } else {
+        var $wrapper = $(wrapperOpen + '<div class="simpleTabsTemporaryWrapper"></div>' + wrapperClose);
+        $firstOpenTag.before($wrapper);
+        $wrapper.find('.simpleTabsTemporaryWrapper')
+            .before(my.$headersContainer)
+            .before(my.$contentsContainer)
+            .remove()
+        ;
     }
-    var tabTitle = $(this).attr("data-tab-title");
-    $(this).after("<h2 class='tab-title'>"+tabTitle+"</h2>").nextUntil(".simpleTabsClose").wrapAll("<div class='simpleTabsContent clearfix' data-tab-id='"+i+"'>");
-    $(".simpleTabs").append("<li data-tab-id="+i+"><a href='javascript:showSimpleTab("+i+");'>"+tabTitle+"</a></li>");
-    i++;        
-});
-$(".simpleTabsOpen:not(.editmode), .simpleTabsClose:not(.editmode)").remove();
-$('.simpleTabsContent').appendTo($('.simpleTabsContainer'));
-$('.simpleTabs li:first-child').addClass('active');
-function showSimpleTab(tabID){
-    $(".simpleTabsContent").hide();
-    $('.simpleTabsContent[data-tab-id="'+tabID+'"]').show();  
-    $('.simpleTabs li').removeClass('active');
-    $('.simpleTabs li[data-tab-id="'+tabID+'"]').addClass('active');
+    $openTags.each(function() {
+        var $openTag = $(this),
+            title = $openTag.attr('data-tab-title'),
+            $header = $('<li />'),
+            $contents = $('<div class="simpleTabsContent clearfix" />')
+        ;
+        $header
+            .data('quick_tabs.contents', $contents)
+            .append($('<a href="#" />')
+                .html(title)
+                .on('click', function(e) {
+                    e.preventDefault();
+                    my.showTab($header);
+                })
+            )
+        ;
+        my.$contentsContainer.append($contents);
+        my.$headersContainer.append($header);
+        $openTag.after($('<h2 class="tab-title" />').html(title));
+        $contents.append($openTag.nextUntil('.simpleTabsClose'));
+    });
+    $openTags.remove();
+    $container.find('.simpleTabsClose').remove();
+    my.showTab(my.$headersContainer.find('li:first-child'));
 }
+QuickTabs.prototype = {
+    showTab: function($header) {
+        this.$headersContainer.find('>li').removeClass('active');
+        $header.addClass('active');
+        this.$contentsContainer.find('>.simpleTabsContent').hide();
+        $header.data('quick_tabs.contents').show();
+    }
+};
+
+(function() {
+    var parsedContainers = [];
+    $('.simpleTabsOpen:not(.editmode)').each(function() {
+        var $container = $(this).parent();
+        if ($container.length === 0) {
+            return;
+        }
+        var container = $container[0];
+        if (parsedContainers.indexOf(container) < 0) {
+            new QuickTabs($container);
+            parsedContainers.push(container);
+        }
+    });
+})();
+
 function windowSizeState(){
-    if($(window).width() < 768){        
-        $(".simpleTabsContent").show();
+    if($(window).width() < WINDOW_WIDTH_STOP) {
+        $('.simpleTabsContent').show();
     }
     else{
-        $(".simpleTabsContent").hide();
-        var activeID = $(".simpleTabs li.active").attr("data-tab-id");
-        $(".simpleTabsContent[data-tab-id='"+activeID+"']").show();
+        $('.simpleTabsContent').hide();
+        $('.simpleTabs li.active').data('quick_tabs.contents').show();
     }
 }
 $(window).resize(function(){
     windowSizeState();
 });
 windowSizeState();
+
+})();

--- a/blocks/quick_tabs/view.js
+++ b/blocks/quick_tabs/view.js
@@ -131,11 +131,20 @@ function QuickTabs($container, index) {
     });
     $openTags.remove();
     $container.find('>.simpleTabsClose').remove();
-    var headerIndex = LocationHash.get(my.index, my.handleToTabIndexMap),
-        selectedHeader = my.$headersContainer.find('>li')[headerIndex];
-    my.showTab(selectedHeader ? $(selectedHeader) : my.$headersContainer.find('>li:first-child'));
+    my.setTabFromLocationHash();
+    $(window).on('hashchange', function() {
+        my.setTabFromLocationHash();
+    });
+    
+        
+    
 }
 QuickTabs.prototype = {
+    setTabFromLocationHash: function() {
+        var headerIndex = LocationHash.get(this.index, this.handleToTabIndexMap),
+            selectedHeader = this.$headersContainer.find('>li')[headerIndex];
+        this.showTab(selectedHeader ? $(selectedHeader) : this.$headersContainer.find('>li:first-child'));
+    },
     showTab: function($header, saveHash) {
         var $headers = this.$headersContainer.find('>li');
         $headers.removeClass('active');

--- a/blocks/quick_tabs/view.js
+++ b/blocks/quick_tabs/view.js
@@ -49,7 +49,7 @@ function QuickTabs($container) {
         $contents.append($openTag.nextUntil('.simpleTabsClose'));
     });
     $openTags.remove();
-    $container.find('.simpleTabsClose').remove();
+    $container.find('>.simpleTabsClose').remove();
     my.showTab(my.$headersContainer.find('li:first-child'));
 }
 QuickTabs.prototype = {

--- a/blocks/quick_tabs/view.js
+++ b/blocks/quick_tabs/view.js
@@ -4,13 +4,84 @@
 
 var WINDOW_WIDTH_STOP = 768;
 
-function QuickTabs($container) {
+var LocationHash = (function() {
+    var CHUNK_SEPARATOR = '|';
+    var SUPPORTED = window.location && typeof window.location.hash === 'string';
+    function getCurrent() {
+        if (!SUPPORTED) {
+            return null;
+        }
+        var result = {
+            others: null,
+            tabs: [],
+        };
+        var hash = window.decodeURIComponent(window.location.hash.replace(/^#/, '')).replace(/^#/, '');
+        $.each(hash.split(CHUNK_SEPARATOR), function (_, chunk) {
+            var match = chunk.match(/^qt(\d+):(\d+)$/);
+            if (match === null) {
+            	if (result.others === null) {
+                    result.others = chunk;
+                } else {
+                    result.others += '|' + chunk;
+                }
+            } else {
+                result.tabs[parseInt(match[1], 10)] = parseInt(match[2], 10);
+            }
+        });
+        return result;
+    }
+    function setCurrent(data) {
+        if (!SUPPORTED || !data) {
+            return;
+        }
+        var chunks = [];
+        if (typeof data.others === 'string' && data.others !== '') {
+            chunks.push(data.others);
+        }
+        $.each(data.tabs, function(index, value) {
+            if (typeof value === 'number') {
+                chunks.push('qt' + index + ':' + value);
+            }
+        });
+        var hash = chunks.join('|');
+        if (hash === '') {
+            try {
+                window.history.replaceState(null, '', ' ');
+            } catch (e) {
+                var x = window.document.body.scrollLeft,
+                    y = window.document.body.scrollTop;
+                window.location.hash = '';
+                window.document.body.scrollLeft = x;
+                window.document.body.scrollTop = y;
+            }
+        } else {
+            window.location.hash = hash;
+        }
+    }
+    return {
+        get: function(quickTabsIndex) {
+            var data = getCurrent();
+            return data === null || !data.tabs[quickTabsIndex] ? 0 : data.tabs[quickTabsIndex];
+        },
+        set: function(quickTabsIndex, headerIndex) {
+            var data = getCurrent();
+            if (data === null) {
+                return;
+            }
+            data.tabs[quickTabsIndex] = headerIndex;
+            setCurrent(data);
+        }
+    };
+})();
+
+function QuickTabs($container, index) {
     var my = this,
         $openTags = $container.find('>.simpleTabsOpen'),
         $firstOpenTag = $openTags.first(),
         wrapperOpen = ($firstOpenTag.data('wrapper-open') || '').toString(),
         wrapperClose = ($firstOpenTag.data('wrapper-close') || '').toString()
     ;
+    my.index = index;
     my.$headersContainer = $('<ul class="simpleTabs clearfix" />');
     my.$contentsContainer = $('<div class="simpleTabsContainer" />');
     if (wrapperOpen === '' && wrapperClose === '') {
@@ -39,7 +110,7 @@ function QuickTabs($container) {
                 .html(title)
                 .on('click', function(e) {
                     e.preventDefault();
-                    my.showTab($header);
+                    my.showTab($header, true);
                 })
             )
         ;
@@ -50,19 +121,26 @@ function QuickTabs($container) {
     });
     $openTags.remove();
     $container.find('>.simpleTabsClose').remove();
-    my.showTab(my.$headersContainer.find('li:first-child'));
+    var headerIndex = LocationHash.get(my.index),
+        selectedHeader = my.$headersContainer.find('>li')[headerIndex];
+    my.showTab(selectedHeader ? $(selectedHeader) : my.$headersContainer.find('>li:first-child'));
 }
 QuickTabs.prototype = {
-    showTab: function($header) {
-        this.$headersContainer.find('>li').removeClass('active');
+    showTab: function($header, saveHash) {
+        var $headers = this.$headersContainer.find('>li');
+        $headers.removeClass('active');
         $header.addClass('active');
         this.$contentsContainer.find('>.simpleTabsContent').hide();
         $header.data('quick_tabs.contents').show();
+        if (saveHash) {
+            LocationHash.set(this.index, $headers.index($header));
+        }
     }
 };
 
 (function() {
-    var parsedContainers = [];
+    var parsedContainers = [],
+        count = 0;
     $('.simpleTabsOpen:not(.editmode)').each(function() {
         var $container = $(this).parent();
         if ($container.length === 0) {
@@ -70,7 +148,7 @@ QuickTabs.prototype = {
         }
         var container = $container[0];
         if (parsedContainers.indexOf(container) < 0) {
-            new QuickTabs($container);
+            new QuickTabs($container, count++);
             parsedContainers.push(container);
         }
     });
@@ -82,7 +160,9 @@ function windowSizeState(){
     }
     else{
         $('.simpleTabsContent').hide();
-        $('.simpleTabs li.active').data('quick_tabs.contents').show();
+        $('.simpleTabs li.active').each(function() {
+            $(this).data('quick_tabs.contents').show();
+        });
     }
 }
 $(window).resize(function(){

--- a/blocks/quick_tabs/view.php
+++ b/blocks/quick_tabs/view.php
@@ -5,14 +5,18 @@ use Concrete\Core\Page\Page;
 defined('C5_EXECUTE') or die('Access Denied.');
 
 /**
+ * @var Concrete\Core\Area\Area $a
  * @var Concrete\Package\QuickTabs\Block\QuickTabs\Controller $controller
  * @var string $openclose
  * @var string $closeOption
  * @var string $semantic
  * @var string $tabTitle
  */
-$c = Page::getCurrentPage();
-$isEditMode = $c->isEditMode();
+$page = Page::getCurrentPage();
+if (!$page || $page->isError()) {
+    $page = null;
+}
+$isEditMode = $page !== null && $page->isEditMode();
 
 //add class depending on what type of block
 if ($openclose !== $closeOption){
@@ -25,6 +29,8 @@ if ($openclose !== $closeOption){
     $tagContents = t('Closing Tab');
     $tabTitle = '';
 }
+$openWrapper = '';
+$closeWrapper = '';
 if ($isEditMode) {
     $class .= ' editmode';
     $editingStyle = ' style="padding: 15px; background: #ccc; color: #444; border: 1px solid #999;"';
@@ -32,12 +38,37 @@ if ($isEditMode) {
 else {
     $editingStyle = '';
     $tagContents = $tabTitle;
+    if (!empty($a) && $a->isGridContainerEnabled()) {
+        if ($page !== null) {
+            $theme = $page->getCollectionThemeObject();
+            if ($theme !== null && $theme->supportsGridFramework()) {
+                $gridFramework = $theme->getThemeGridFrameworkObject();
+                if ($gridFramework !== null) {
+                    $openWrapper = $gridFramework->getPageThemeGridFrameworkContainerStartHTML() .
+                        $gridFramework->getPageThemeGridFrameworkRowStartHTML() .
+                        sprintf(
+                            '<div class="%s">',
+                            $gridFramework->getPageThemeGridFrameworkColumnClassesForSpan(
+                                min($a->getAreaGridMaximumColumns(), $gridFramework->getPageThemeGridFrameworkNumColumns())
+                            )
+                        );
+
+                    $closeWrapper = '</div>' .
+                        $gridFramework->getPageThemeGridFrameworkRowEndHTML() .
+                        $gridFramework->getPageThemeGridFrameworkContainerEndHTML()
+                    ;
+                }
+            }
+        }
+    }
 }
 printf(
-    '<%1$s data-tab-title="%2$s" class="%3$s"%4$s>%5$s</%1$s>',
+    '<%1$s data-tab-title="%2$s" data-wrapper-open="%3$s" data-wrapper-close="%4$s" class="%5$s"%6$s>%7$s</%1$s>',
     $tag, // %1$s
     h($tabTitle), // %2$s
-    $class, // %3$s
-    $editingStyle, // %4$s
-    $tagContents // %5$s
+    h($openWrapper), // %3$s
+    h($closeWrapper), // %4$s
+    $class, // %5$s
+    $editingStyle, // %6$s
+    $tagContents // %7$s
 );

--- a/blocks/quick_tabs/view.php
+++ b/blocks/quick_tabs/view.php
@@ -1,28 +1,26 @@
 <?php
-    defined('C5_EXECUTE') or die(_("Access Denied.")); 
-	
-    $c = Page::getCurrentPage();
-	//add class depending on what type of block
-	if($openclose=="open"){
-		$class='simpleTabsOpen';
-		$state="opening";
-		$tag = $semantic;
-	}else{
-		$class="simpleTabsClose";	
-		$state="closing";
-		$tag = "div";
-	}
-	if ($c->isEditMode()){
-		$class=$class+" editmode";	
-		$editingStyle = "";
-		$status = $tabTitle." ".$state." block";
-		$editingStyle=" style='padding: 15px; background: #ccc; color: #444; border: 1px solid #999;'";
-	}
-	else {  
-		$editingStyle = "";
-		$status = $tabTitle;
-	}
+defined('C5_EXECUTE') or die('Access Denied.');
+
+$c = Page::getCurrentPage();
+//add class depending on what type of block
+if ($openclose === 'open'){
+    $class = 'simpleTabsOpen';
+    $state = 'opening';
+    $tag = $semantic;
+} else {
+    $class = 'simpleTabsClose';
+    $state = 'closing';
+    $tag = 'div';
+}
+if ($c->isEditMode()) {
+    $class .= ' editmode';
+    $editingStyle = '';
+    $status = $tabTitle . ' ' . $state . ' block';
+    $editingStyle = " style='padding: 15px; background: #ccc; color: #444; border: 1px solid #999;'";
+}
+else {
+    $editingStyle = '';
+    $status = $tabTitle;
+}
 ?>
-
-
-<<?=$tag?> data-tab-title="<?=$tabTitle?>" class="<?=$class?>"<?=$editingStyle?>><?=$status?></<?=$tag?>>
+<<?php echo $tag; ?> data-tab-title="<?php echo $tabTitle; ?>" class="<?php echo $class; ?>"<?php echo $editingStyle; ?>><?php echo $status; ?></<?php echo $tag; ?>>

--- a/blocks/quick_tabs/view.php
+++ b/blocks/quick_tabs/view.php
@@ -7,31 +7,37 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /**
  * @var Concrete\Package\QuickTabs\Block\QuickTabs\Controller $controller
  * @var string $openclose
+ * @var string $closeOption
  * @var string $semantic
  * @var string $tabTitle
  */
-
 $c = Page::getCurrentPage();
+$isEditMode = $c->isEditMode();
 
 //add class depending on what type of block
-if ($openclose === 'open'){
+if ($openclose !== $closeOption){
     $class = 'simpleTabsOpen';
-    $state = 'opening';
     $tag = $semantic;
+    $tagContents = t('Opening Tab "%s"', $tabTitle);
 } else {
     $class = 'simpleTabsClose';
-    $state = 'closing';
     $tag = 'div';
+    $tagContents = t('Closing Tab');
+    $tabTitle = '';
 }
-if ($c->isEditMode()) {
+if ($isEditMode) {
     $class .= ' editmode';
-    $editingStyle = '';
-    $status = $tabTitle . ' ' . $state . ' block';
-    $editingStyle = " style='padding: 15px; background: #ccc; color: #444; border: 1px solid #999;'";
+    $editingStyle = ' style="padding: 15px; background: #ccc; color: #444; border: 1px solid #999;"';
 }
 else {
     $editingStyle = '';
-    $status = $tabTitle;
+    $tagContents = $tabTitle;
 }
-?>
-<<?php echo $tag; ?> data-tab-title="<?php echo $tabTitle; ?>" class="<?php echo $class; ?>"<?php echo $editingStyle; ?>><?php echo $status; ?></<?php echo $tag; ?>>
+printf(
+    '<%1$s data-tab-title="%2$s" class="%3$s"%4$s>%5$s</%1$s>',
+    $tag, // %1$s
+    h($tabTitle), // %2$s
+    $class, // %3$s
+    $editingStyle, // %4$s
+    $tagContents // %5$s
+);

--- a/blocks/quick_tabs/view.php
+++ b/blocks/quick_tabs/view.php
@@ -1,7 +1,18 @@
 <?php
+
+use Concrete\Core\Page\Page;
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
+/**
+ * @var Concrete\Package\QuickTabs\Block\QuickTabs\Controller $controller
+ * @var string $openclose
+ * @var string $semantic
+ * @var string $tabTitle
+ */
+
 $c = Page::getCurrentPage();
+
 //add class depending on what type of block
 if ($openclose === 'open'){
     $class = 'simpleTabsOpen';

--- a/config/options.php
+++ b/config/options.php
@@ -1,0 +1,8 @@
+<?php
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+return array(
+    // Custom list of allowed tags (example: 'h2, h3, h4, p, span')
+    'custom_tags'  => '',
+);

--- a/controller.php
+++ b/controller.php
@@ -13,7 +13,7 @@ class Controller extends Package
 
 	protected $appVersionRequired = '5.7.1';
 
-	protected $pkgVersion = '1.0';
+	protected $pkgVersion = '1.1.0';
 
 	/**
 	 * {@inheritdoc}

--- a/controller.php
+++ b/controller.php
@@ -1,35 +1,48 @@
-<?php      
+<?php 
 
 namespace Concrete\Package\QuickTabs;
-use Package;
-use BlockType;
 
-defined('C5_EXECUTE') or die(_("Access Denied."));
+use Concrete\Core\Block\BlockType\BlockType;
+use Concrete\Core\Package\Package;
+
+defined('C5_EXECUTE') or die(_('Access Denied.'));
 
 class Controller extends Package
 {
-
 	protected $pkgHandle = 'quick_tabs';
-	protected $appVersionRequired = '5.7.1';
-	protected $pkgVersion = '1.0';
-	
-	
-	
-	public function getPackageDescription()
-	{
-		return t("Add Tabs to your site");
-	}
 
+	protected $appVersionRequired = '5.7.1';
+
+	protected $pkgVersion = '1.0';
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @see \Concrete\Core\Package\Package::getPackageName()
+	 */
 	public function getPackageName()
 	{
-		return t("Quick Tabs");
+		return t('Quick Tabs');
 	}
-	
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @see \Concrete\Core\Package\Package::getPackageDescription()
+	 */
+	public function getPackageDescription()
+	{
+	    return t('Add Tabs to your site');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @see \Concrete\Core\Package\Package::install()
+	 */
 	public function install()
 	{
 		$pkg = parent::install();
-        BlockType::installBlockTypeFromPackage('quick_tabs', $pkg); 
-        
+		BlockType::installBlockType('quick_tabs', $pkg);
 	}
 }
-?>


### PR DESCRIPTION
Multiple improvements here:

1. check the data specified by users when they add/edit the block
2. don't ask for useless data when add/edit block (that is, hide `tabTitle` and `semantic` input fields when adding a `close` block)
3. allow customizing the list of allowed HTML tags (the value of the `semantic` field)
4. some fixes so that my [IDE](https://www.eclipse.org/pdt/) doesn't warn me about undefined variables
5. translate the texts `<Tab Name> opening block` and `Closing block`
6. add support for multiple tabs in the same page (we assume that opening/closing blocks in the same `div` element are for the same tab set - so users can add multiple tab sets in different page areas)
7. add support for grid framework
